### PR TITLE
Reduce the memory usage by leaving values as the arrays they are

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -44,7 +44,7 @@ type metaData struct {
 	CompleteTime  string
 }
 
-const version = "0.3.4"
+const version = "0.3.5"
 
 const headerTmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --

--- a/dump_test.go
+++ b/dump_test.go
@@ -208,7 +208,7 @@ func TestCreateTableValuesOk(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 
-	expectedResult := "('1','test@test.de','Test Name 1'),('2','test2@test.de','Test Name 2')"
+	expectedResult := []string{"('1','test@test.de','Test Name 1')", "('2','test2@test.de','Test Name 2')"}
 
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Fatalf("expected %#v, got %#v", expectedResult, result)
@@ -244,7 +244,7 @@ func TestCreateTableValuesNil(t *testing.T) {
 		t.Errorf("there were unfulfilled expections: %s", err)
 	}
 
-	expectedResult := "('1',NULL,'Test Name 1'),('2','test2@test.de','Test Name 2'),('3','','Test Name 3')"
+	expectedResult := []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')", "('3','','Test Name 3')"}
 
 	if !reflect.DeepEqual(result, expectedResult) {
 		t.Fatalf("expected %#v, got %#v", expectedResult, result)

--- a/dump_test.go
+++ b/dump_test.go
@@ -286,7 +286,7 @@ func TestCreateTableOk(t *testing.T) {
 	expectedResult := &table{
 		Name:   "`Test_Table`",
 		SQL:    "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1",
-		Values: "('1',NULL,'Test Name 1'),('2','test2@test.de','Test Name 2')",
+		Values: []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')"},
 	}
 
 	if !reflect.DeepEqual(result, expectedResult) {

--- a/mysqldump_test.go
+++ b/mysqldump_test.go
@@ -96,6 +96,6 @@ UNLOCK TABLES;
 `
 
 	if !reflect.DeepEqual(result, expected) {
-		t.Fatalf("expected %#v, got %#v", expected, result)
+		t.Fatalf("expected \n%#v, got \n%#v", expected, result)
 	}
 }


### PR DESCRIPTION
This reduces the memory because we don't have to malloc the space for combined strings and hold.

Reduces memory usage so now we only require n + x bytes in memory for the largest table instead of 2(n+x) for the largest table.