### PR TITLE
Switch to use go channels

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -84,10 +84,10 @@ DROP TABLE IF EXISTS {{ .NameEsc }};
 
 LOCK TABLES {{ .NameEsc }} WRITE;
 /*!40000 ALTER TABLE {{ .Name }} DISABLE KEYS */;
-{{- if .Values }}
-INSERT INTO {{ .Name }} VALUES
+{{- if .Next }}
+INSERT INTO {{ .Name }} VALUES {{ .RowValues }}
 {{- range .Next -}}
-, {{ end -}}{{ .RowValues }}
+, {{ .RowValues }}
 {{- end -}};
 {{- end }}
 /*!40000 ALTER TABLE {{ .Name }} ENABLE KEYS */;
@@ -319,7 +319,9 @@ func (table *table) Next() bool {
 			table.Err = err
 			return false
 		}
-	} else if table.rows.Next() {
+	}
+	// Fallthrough
+	if table.rows.Next() {
 		if err := table.rows.Scan(table.values...); err != nil {
 			table.Err = err
 			return false

--- a/dump.go
+++ b/dump.go
@@ -47,6 +47,7 @@ type metaData struct {
 
 const version = "0.3.5"
 
+// takes a *metaData
 const headerTmpl = `-- Go SQL Dump {{ .DumpVersion }}
 --
 -- ------------------------------------------------------
@@ -64,6 +65,21 @@ const headerTmpl = `-- Go SQL Dump {{ .DumpVersion }}
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 `
 
+// takes a *metaData
+const footerTmpl = `/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on {{ .CompleteTime }}
+`
+
+// Takes a *table
 const tableTmpl = `
 --
 -- Table structure for table {{ .NameEsc }}
@@ -87,19 +103,6 @@ INSERT INTO {{ .NameEsc }} VALUES {{ .RowValues }}
 {{- end }}
 /*!40000 ALTER TABLE {{ .NameEsc }} ENABLE KEYS */;
 UNLOCK TABLES;
-`
-
-const footerTmpl = `/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
-
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-
--- Dump completed on {{ .CompleteTime }}
 `
 
 const nullType = "NULL"

--- a/dump.go
+++ b/dump.go
@@ -45,7 +45,7 @@ type metaData struct {
 	CompleteTime  string
 }
 
-const version = "0.3.5"
+const version = "0.4.0"
 
 // takes a *metaData
 const headerTmpl = `-- Go SQL Dump {{ .DumpVersion }}

--- a/dump_test.go
+++ b/dump_test.go
@@ -5,14 +5,12 @@ import (
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTablesOk(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"Tables_in_Testdb"}).
@@ -26,28 +24,17 @@ func TestGetTablesOk(t *testing.T) {
 	}
 
 	result, err := data.getTables()
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err)
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := []string{"Test_Table_1", "Test_Table_2"}
-
-	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", result, expectedResult)
-	}
+	assert.EqualValues(t, []string{"Test_Table_1", "Test_Table_2"}, result)
 }
 
 func TestIgnoreTablesOk(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"Tables_in_Testdb"}).
@@ -62,27 +49,17 @@ func TestIgnoreTablesOk(t *testing.T) {
 	}
 
 	result, err := data.getTables()
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err)
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := []string{"Test_Table_2"}
-
-	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", result, expectedResult)
-	}
+	assert.EqualValues(t, []string{"Test_Table_2"}, result)
 }
 
 func TestGetTablesNil(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 
 	defer db.Close()
 
@@ -98,27 +75,17 @@ func TestGetTablesNil(t *testing.T) {
 	}
 
 	result, err := data.getTables()
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, err)
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := []string{"Test_Table_1", "Test_Table_3"}
-
-	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", expectedResult, result)
-	}
+	assert.EqualValues(t, []string{"Test_Table_1", "Test_Table_3"}, result)
 }
 
 func TestGetServerVersionOk(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 
 	defer db.Close()
 
@@ -129,28 +96,17 @@ func TestGetServerVersionOk(t *testing.T) {
 
 	meta := metaData{}
 
-	if err := meta.updateServerVersion(db); err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	assert.NoError(t, meta.updateServerVersion(db), "error was not expected while updating stats")
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := "test_version"
-
-	if !reflect.DeepEqual(meta.ServerVersion, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", expectedResult, meta.ServerVersion)
-	}
+	assert.Equal(t, "test_version", meta.ServerVersion)
 }
 
 func TestCreateTableSQLOk(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"Table", "Create Table"}).
@@ -162,16 +118,14 @@ func TestCreateTableSQLOk(t *testing.T) {
 		Connection: db,
 	}
 
-	result, err := data.createTableSQL("Test_Table")
+	table, err := data.createTable("Test_Table")
+	assert.NoError(t, err)
 
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	result, err := table.CreateSQL()
+	assert.NoError(t, err)
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
 	expectedResult := "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1"
 
@@ -180,12 +134,9 @@ func TestCreateTableSQLOk(t *testing.T) {
 	}
 }
 
-func TestCreateTableValuesOk(t *testing.T) {
+func TestCreateTableRowValues(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "email", "name"}).
@@ -198,29 +149,23 @@ func TestCreateTableValuesOk(t *testing.T) {
 		Connection: db,
 	}
 
-	result, err := data.createTableValues("test")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
-	}
+	table, err := data.createTable("test")
+	assert.NoError(t, err)
+
+	assert.True(t, table.Next())
+	// TODO
+	result, err := table.RowValues()
+	assert.NoError(t, err)
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := []string{"('1','test@test.de','Test Name 1')", "('2','test2@test.de','Test Name 2')"}
-
-	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", expectedResult, result)
-	}
+	assert.EqualValues(t, "('1','test@test.de','Test Name 1')", result)
 }
 
-func TestCreateTableValuesNil(t *testing.T) {
+func TestCreateTableAllValuesWithNil(t *testing.T) {
 	db, mock, err := sqlmock.New()
-	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
-	}
-
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "email", "name"}).
@@ -234,21 +179,22 @@ func TestCreateTableValuesNil(t *testing.T) {
 		Connection: db,
 	}
 
-	result, err := data.createTableValues("test")
-	if err != nil {
-		t.Errorf("error was not expected while updating stats: %s", err)
+	table, err := data.createTable("test")
+	assert.NoError(t, err)
+
+	results := make([]string, 0)
+	for table.Next() {
+		row, err := table.RowValues()
+		assert.NoError(t, err)
+		results = append(results, row)
 	}
 
 	// we make sure that all expectations were met
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("there were unfulfilled expections: %s", err)
-	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
 
-	expectedResult := []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')", "('3','','Test Name 3')"}
+	expectedResults := []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')", "('3','','Test Name 3')"}
 
-	if !reflect.DeepEqual(result, expectedResult) {
-		t.Fatalf("expected %#v, got %#v", expectedResult, result)
-	}
+	assert.EqualValues(t, expectedResults, results)
 }
 
 func TestCreateTableOk(t *testing.T) {
@@ -284,9 +230,9 @@ func TestCreateTableOk(t *testing.T) {
 	}
 
 	expectedResult := &table{
-		Name:   "`Test_Table`",
-		SQL:    "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1",
-		Values: []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')"},
+		Name: "`Test_Table`",
+		// SQL:    "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1",
+		// Values: []string{"('1',NULL,'Test Name 1')", "('2','test2@test.de','Test Name 2')"},
 	}
 
 	if !reflect.DeepEqual(result, expectedResult) {


### PR DESCRIPTION
Switch from _goroutines_ storing rows in memory to use a channel with a buffer of 1 to hold single rows so we can dump tables that far exceed your system memory. Now we have a _goroutine_ blocking and then filling a buffer for the dump.

The buffer of 1 is what maintains the speed that this has had with the memory improvements. This way we can read from MySQL and write to the file in parallel and not block either. Making this a typical consumer producer problem for memory. The table rows are dynamically allocated so usage is usually fairly small.

> NOTE: MySQL rows have a max of 1GB so we can theoretically use 3GB of heap. If the buffer is full and there is one waiting to get put into the buffer. The io.Writter is writing to a memory buffer for the previous in the channel.
> I have gotten no where near this limit being only able to put rows of 128MB in MySQL before I got weird server unavailable errors and sometimes corrupted MySQL databases entirely.