### PR TITLE
Now stream INSERT statements.

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -47,7 +47,7 @@ type metaData struct {
 }
 
 const (
-	// Version is exported for other builds
+	// Version of this plugin for easy reference
 	Version = "0.4.1"
 
 	defaultMaxAllowedPacket = 4194304

--- a/dump.go
+++ b/dump.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"runtime"
 	"text/template"
 	"time"
 )
@@ -395,17 +394,6 @@ func (table *table) Stream() <-chan string {
 				insert.WriteString(",")
 			}
 			b.WriteTo(&insert)
-
-			// debug
-			var m runtime.MemStats
-			runtime.ReadMemStats(&m)
-			// For info on each, see: https://golang.org/pkg/runtime/#MemStats
-			fmt.Print("\tBuffer = ", bToMiB(uint64(insert.Len())), " MiB")
-			fmt.Print("\tCapacity = ", bToMiB(uint64(insert.Cap())), " MiB")
-			fmt.Print("\tAlloc = ", bToMiB(m.Alloc), " MiB")
-			fmt.Print("\tTotalAlloc = ", bToMiB(m.TotalAlloc), " MiB")
-			fmt.Print("\tSys = ", bToMiB(m.Sys), " MiB")
-			fmt.Print("\tNumGC = ", m.NumGC, "\n")
 		}
 		if insert.Len() != 0 {
 			insert.WriteString(";")
@@ -413,8 +401,4 @@ func (table *table) Stream() <-chan string {
 		}
 	}()
 	return valueOut
-}
-
-func bToMiB(b uint64) uint64 {
-	return b / 1024 / 1024
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -165,6 +165,59 @@ func TestCreateTableRowValues(t *testing.T) {
 	assert.EqualValues(t, "('1','test@test.de','Test Name 1')", result)
 }
 
+func TestCreateTableValuesSteam(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "email", "name"}).
+		AddRow(1, "test@test.de", "Test Name 1").
+		AddRow(2, "test2@test.de", "Test Name 2")
+
+	mock.ExpectQuery("^SELECT (.+) FROM `test`$").WillReturnRows(rows)
+
+	data := Data{
+		Connection:       db,
+		MaxAllowedPacket: 4096,
+	}
+
+	table, err := data.createTable("test")
+	assert.NoError(t, err)
+
+	s := table.Stream()
+	assert.EqualValues(t, "INSERT INTO `test` VALUES ('1','test@test.de','Test Name 1'),('2','test2@test.de','Test Name 2');", <-s)
+
+	// we make sure that all expectations were met
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
+}
+
+func TestCreateTableValuesSteamSmallPackets(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
+	defer db.Close()
+
+	rows := sqlmock.NewRows([]string{"id", "email", "name"}).
+		AddRow(1, "test@test.de", "Test Name 1").
+		AddRow(2, "test2@test.de", "Test Name 2")
+
+	mock.ExpectQuery("^SELECT (.+) FROM `test`$").WillReturnRows(rows)
+
+	data := Data{
+		Connection:       db,
+		MaxAllowedPacket: 64,
+	}
+
+	table, err := data.createTable("test")
+	assert.NoError(t, err)
+
+	s := table.Stream()
+	assert.EqualValues(t, "INSERT INTO `test` VALUES ('1','test@test.de','Test Name 1');", <-s)
+	assert.EqualValues(t, "INSERT INTO `test` VALUES ('2','test2@test.de','Test Name 2');", <-s)
+
+	// we make sure that all expectations were met
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
+}
+
 func TestCreateTableAllValuesWithNil(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
@@ -217,8 +270,9 @@ func TestCreateTableOk(t *testing.T) {
 
 	var buf bytes.Buffer
 	data := Data{
-		Connection: db,
-		Out:        &buf,
+		Connection:       db,
+		Out:              &buf,
+		MaxAllowedPacket: 4096,
 	}
 
 	assert.NoError(t, data.getTemplates())
@@ -249,6 +303,65 @@ CREATE TABLE 'Test_Table' (~id~ int(11) NOT NULL AUTO_INCREMENT,~s~ char(60) DEF
 LOCK TABLES ~Test_Table~ WRITE;
 /*!40000 ALTER TABLE ~Test_Table~ DISABLE KEYS */;
 INSERT INTO ~Test_Table~ VALUES ('1',NULL,'Test Name 1'),('2','test2@test.de','Test Name 2');
+/*!40000 ALTER TABLE ~Test_Table~ ENABLE KEYS */;
+UNLOCK TABLES;
+`
+	result := strings.Replace(buf.String(), "`", "~", -1)
+	assert.Equal(t, expectedResult, result)
+}
+
+func TestCreateTableOkSmallPackets(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err, "an error was not expected when opening a stub database connection")
+
+	defer db.Close()
+
+	createTableRows := sqlmock.NewRows([]string{"Table", "Create Table"}).
+		AddRow("Test_Table", "CREATE TABLE 'Test_Table' (`id` int(11) NOT NULL AUTO_INCREMENT,`s` char(60) DEFAULT NULL, PRIMARY KEY (`id`))ENGINE=InnoDB DEFAULT CHARSET=latin1")
+
+	createTableValueRows := sqlmock.NewRows([]string{"id", "email", "name"}).
+		AddRow(1, nil, "Test Name 1").
+		AddRow(2, "test2@test.de", "Test Name 2")
+
+	mock.ExpectQuery("^SHOW CREATE TABLE `Test_Table`$").WillReturnRows(createTableRows)
+	mock.ExpectQuery("^SELECT (.+) FROM `Test_Table`$").WillReturnRows(createTableValueRows)
+
+	var buf bytes.Buffer
+	data := Data{
+		Connection:       db,
+		Out:              &buf,
+		MaxAllowedPacket: 64,
+	}
+
+	assert.NoError(t, data.getTemplates())
+
+	table, err := data.createTable("Test_Table")
+	assert.NoError(t, err)
+
+	data.writeTable(table)
+
+	// we make sure that all expectations were met
+	assert.NoError(t, mock.ExpectationsWereMet(), "there were unfulfilled expections")
+
+	expectedResult := `
+--
+-- Table structure for table ~Test_Table~
+--
+
+DROP TABLE IF EXISTS ~Test_Table~;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+ SET character_set_client = utf8mb4 ;
+CREATE TABLE 'Test_Table' (~id~ int(11) NOT NULL AUTO_INCREMENT,~s~ char(60) DEFAULT NULL, PRIMARY KEY (~id~))ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table ~Test_Table~
+--
+
+LOCK TABLES ~Test_Table~ WRITE;
+/*!40000 ALTER TABLE ~Test_Table~ DISABLE KEYS */;
+INSERT INTO ~Test_Table~ VALUES ('1',NULL,'Test Name 1');
+INSERT INTO ~Test_Table~ VALUES ('2','test2@test.de','Test Name 2');
 /*!40000 ALTER TABLE ~Test_Table~ ENABLE KEYS */;
 UNLOCK TABLES;
 `

--- a/mysqldump_test.go
+++ b/mysqldump_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const expected = `-- Go SQL Dump ` + version + `
+const expected = `-- Go SQL Dump ` + Version + `
 --
 -- ------------------------------------------------------
 -- Server version	test_version


### PR DESCRIPTION
We try to dump a mysql's default packet size per insert statement if we exceed that we just make larger statements. This then allows us to restore tables that are larger than MySQL's `max_packet_size`