### PR TITLE
Add the ability to lock all tables

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -49,7 +49,7 @@ type metaData struct {
 
 const (
 	// Version of this plugin for easy reference
-	Version = "0.4.1"
+	Version = "0.5.0"
 
 	defaultMaxAllowedPacket = 4194304
 )

--- a/dump_test.go
+++ b/dump_test.go
@@ -120,8 +120,7 @@ func TestCreateTableSQLOk(t *testing.T) {
 		Connection: db,
 	}
 
-	table, err := data.createTable("Test_Table")
-	assert.NoError(t, err)
+	table := data.createTable("Test_Table")
 
 	result, err := table.CreateSQL()
 	assert.NoError(t, err)
@@ -151,8 +150,7 @@ func TestCreateTableRowValues(t *testing.T) {
 		Connection: db,
 	}
 
-	table, err := data.createTable("test")
-	assert.NoError(t, err)
+	table := data.createTable("test")
 
 	assert.True(t, table.Next())
 
@@ -181,8 +179,7 @@ func TestCreateTableValuesSteam(t *testing.T) {
 		MaxAllowedPacket: 4096,
 	}
 
-	table, err := data.createTable("test")
-	assert.NoError(t, err)
+	table := data.createTable("test")
 
 	s := table.Stream()
 	assert.EqualValues(t, "INSERT INTO `test` VALUES ('1','test@test.de','Test Name 1'),('2','test2@test.de','Test Name 2');", <-s)
@@ -207,8 +204,7 @@ func TestCreateTableValuesSteamSmallPackets(t *testing.T) {
 		MaxAllowedPacket: 64,
 	}
 
-	table, err := data.createTable("test")
-	assert.NoError(t, err)
+	table := data.createTable("test")
 
 	s := table.Stream()
 	assert.EqualValues(t, "INSERT INTO `test` VALUES ('1','test@test.de','Test Name 1');", <-s)
@@ -234,8 +230,7 @@ func TestCreateTableAllValuesWithNil(t *testing.T) {
 		Connection: db,
 	}
 
-	table, err := data.createTable("test")
-	assert.NoError(t, err)
+	table := data.createTable("test")
 
 	results := make([]string, 0)
 	for table.Next() {
@@ -277,8 +272,7 @@ func TestCreateTableOk(t *testing.T) {
 
 	assert.NoError(t, data.getTemplates())
 
-	table, err := data.createTable("Test_Table")
-	assert.NoError(t, err)
+	table := data.createTable("Test_Table")
 
 	data.writeTable(table)
 
@@ -335,8 +329,7 @@ func TestCreateTableOkSmallPackets(t *testing.T) {
 
 	assert.NoError(t, data.getTemplates())
 
-	table, err := data.createTable("Test_Table")
-	assert.NoError(t, err)
+	table := data.createTable("Test_Table")
 
 	data.writeTable(table)
 

--- a/mysqldump.go
+++ b/mysqldump.go
@@ -39,17 +39,17 @@ func Register(db *sql.DB, dir, format string) (*Data, error) {
 	return &Data{
 		Out:        f,
 		Connection: db,
+		LockTables: true,
 	}, nil
 }
 
 // Dump Creates a MYSQL dump from the connection to the stream.
 func Dump(db *sql.DB, out io.Writer) error {
-	data := Data{
+	return (&Data{
 		Connection: db,
 		Out:        out,
-	}
-
-	return data.Dump()
+		LockTables: true,
+	}).Dump()
 }
 
 // Close the dumper.


### PR DESCRIPTION
Add the ability to lock all tables before dumping so we don't get bad or partial data.