### PR TITLE
Single transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.11.x
+  - 1.13.x
   - master
 
 script:

--- a/dump.go
+++ b/dump.go
@@ -52,7 +52,7 @@ type metaData struct {
 
 const (
 	// Version of this plugin for easy reference
-	Version = "0.6.0"
+	Version = "0.5.0"
 
 	defaultMaxAllowedPacket = 4194304
 )

--- a/dump.go
+++ b/dump.go
@@ -325,6 +325,7 @@ func (table *table) Init() (err error) {
 	}
 
 	table.types = make([]reflect.Type, len(tt))
+	table.values = make([]interface{}, len(tt))
 	for i, tp := range tt {
 		st := tp.ScanType()
 		if tp.DatabaseTypeName() == "BLOB" {
@@ -338,9 +339,6 @@ func (table *table) Init() (err error) {
 		} else {
 			table.types[i] = reflect.TypeOf(sql.NullString{})
 		}
-	}
-	table.values = make([]interface{}, len(tt))
-	for i := range table.values {
 		table.values[i] = reflect.New(table.types[i]).Interface()
 	}
 	return nil

--- a/dump.go
+++ b/dump.go
@@ -18,7 +18,7 @@ Data struct to configure dump behavior
     Out:              Stream to wite to
     Connection:       Database connection to dump
     IgnoreTables:     Mark sensitive tables to ignore
-	MaxAllowedPacket: Sets the largest packet size to use in backups
+    MaxAllowedPacket: Sets the largest packet size to use in backups
     LockTables:       Lock all tables for the duration of the dump
 */
 type Data struct {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/BrandonRoehl/go-mysqldump
+
+require (
+	github.com/DATA-DOG/go-sqlmock v1.3.0
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
-module github.com/BrandonRoehl/go-mysqldump
+module github.com/jamf/go-mysqldump
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.0
 	github.com/stretchr/testify v1.4.0
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,13 @@
+github.com/DATA-DOG/go-sqlmock v1.3.0 h1:ljjRxlddjfChBJdFKJs5LuCwCWPLaC1UZLwAo3PBBMk=
+github.com/DATA-DOG/go-sqlmock v1.3.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/mysqldump.go
+++ b/mysqldump.go
@@ -39,7 +39,6 @@ func Register(db *sql.DB, dir, format string) (*Data, error) {
 	return &Data{
 		Out:        f,
 		Connection: db,
-		LockTables: true,
 	}, nil
 }
 
@@ -48,7 +47,6 @@ func Dump(db *sql.DB, out io.Writer) error {
 	return (&Data{
 		Connection: db,
 		Out:        out,
-		LockTables: true,
 	}).Dump()
 }
 

--- a/mysqldump_test.go
+++ b/mysqldump_test.go
@@ -76,11 +76,13 @@ func RunDump(t testing.TB, data *Data) {
 		AddRow(1, nil, "Test Name 1").
 		AddRow(2, "test2@test.de", "Test Name 2")
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`^SELECT version\(\)$`).WillReturnRows(serverVersionRows)
-	mock.ExpectQuery("^SHOW TABLES$").WillReturnRows(showTablesRows)
+	mock.ExpectQuery(`^SHOW TABLES$`).WillReturnRows(showTablesRows)
 	mock.ExpectExec("^LOCK TABLES `Test_Table` READ /\\*!32311 LOCAL \\*/$").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectQuery("^SHOW CREATE TABLE `Test_Table`$").WillReturnRows(createTableRows)
 	mock.ExpectQuery("^SELECT (.+) FROM `Test_Table`$").WillReturnRows(createTableValueRows)
+	mock.ExpectRollback()
 
 	assert.NoError(t, data.Dump(), "an error was not expected when dumping a stub database connection")
 }
@@ -124,10 +126,12 @@ func TestNoLockOk(t *testing.T) {
 		AddRow(1, nil, "Test Name 1").
 		AddRow(2, "test2@test.de", "Test Name 2")
 
+	mock.ExpectBegin()
 	mock.ExpectQuery(`^SELECT version\(\)$`).WillReturnRows(serverVersionRows)
-	mock.ExpectQuery("^SHOW TABLES$").WillReturnRows(showTablesRows)
+	mock.ExpectQuery(`^SHOW TABLES$`).WillReturnRows(showTablesRows)
 	mock.ExpectQuery("^SHOW CREATE TABLE `Test_Table`$").WillReturnRows(createTableRows)
 	mock.ExpectQuery("^SELECT (.+) FROM `Test_Table`$").WillReturnRows(createTableValueRows)
+	mock.ExpectRollback()
 
 	assert.NoError(t, data.Dump(), "an error was not expected when dumping a stub database connection")
 


### PR DESCRIPTION
- Convert to use `go.mod`
- Use [`sql.BeginTx`](https://golang.org/pkg/database/sql/#DB.BeginTx) with [`sql.LevelRepeatableRead`](https://golang.org/pkg/database/sql/#IsolationLevel) so you don't need to lock tables to get consistent dumps.

> **NOTE:** If using a non transactional database you will still need to lock the tables.